### PR TITLE
Just works [on 0.5]?

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ precision types are very flexible, but fixed-precision types such
 as those in DecFP are much faster (though still about 100x slower than
 the hardware binary floating-point types `Float32` and `Float64`).
 
-The DecFP package currently requires the Julia 0.4 release, and
-hence is mainly for developers at this point.
+The DecFP package currently requires the Julia 0.4 release or later.
 
 ## Usage
 


### PR DESCRIPTION
"and hence is mainly for developers at this point"

What package isn't for "developers"..?

Just seemed old, for 0.4-dev.

[ci skip]