### PR TITLE
Add trunc and Integer methods for floor, ceil, convert

### DIFF
--- a/src/DecFP.jl
+++ b/src/DecFP.jl
@@ -177,10 +177,19 @@ for w in (32,64,128)
         end
     end
 
+    i′ = string("Int", Sys.WORD_SIZE)
+    Ti′ = eval(Symbol(i′))
+    @eval begin
+        Base.trunc(::Type{Integer}, x::$BID) = xchk(ccall(($(bidsym(w,"to_",lowercase(i′),"_xint")), libbid), $Ti′, ($BID,), x), InexactError, INVALID | OVERFLOW)
+        Base.floor(::Type{Integer}, x::$BID) = xchk(ccall(($(bidsym(w,"to_",lowercase(i′),"_xfloor")), libbid), $Ti′, ($BID,), x), InexactError, INVALID | OVERFLOW)
+        Base.ceil(::Type{Integer}, x::$BID) = xchk(ccall(($(bidsym(w,"to_",lowercase(i′),"_xceil")), libbid), $Ti′, ($BID,), x), InexactError, INVALID | OVERFLOW)
+        Base.convert(::Type{Integer}, x::$BID) = xchk(ccall(($(bidsym(w,"to_",lowercase(i′),"_xfloor")), libbid), $Ti′, ($BID,), x), InexactError)
+    end
     for w′ in (8,16,32,64)
         for i′ in ("Int$w′", "UInt$w′")
             Ti′ = eval(Symbol(i′))
             @eval begin
+                Base.trunc(::Type{$Ti′}, x::$BID) = xchk(ccall(($(bidsym(w,"to_",lowercase(i′),"_xint")), libbid), $Ti′, ($BID,), x), InexactError, INVALID | OVERFLOW)
                 Base.floor(::Type{$Ti′}, x::$BID) = xchk(ccall(($(bidsym(w,"to_",lowercase(i′),"_xfloor")), libbid), $Ti′, ($BID,), x), InexactError, INVALID | OVERFLOW)
                 Base.ceil(::Type{$Ti′}, x::$BID) = xchk(ccall(($(bidsym(w,"to_",lowercase(i′),"_xceil")), libbid), $Ti′, ($BID,), x), InexactError, INVALID | OVERFLOW)
                 Base.convert(::Type{$Ti′}, x::$BID) = xchk(ccall(($(bidsym(w,"to_",lowercase(i′),"_xfloor")), libbid), $Ti′, ($BID,), x), InexactError)

--- a/src/DecFP.jl
+++ b/src/DecFP.jl
@@ -177,14 +177,6 @@ for w in (32,64,128)
         end
     end
 
-    i′ = string("Int", Sys.WORD_SIZE)
-    Ti′ = eval(Symbol(i′))
-    @eval begin
-        Base.trunc(::Type{Integer}, x::$BID) = xchk(ccall(($(bidsym(w,"to_",lowercase(i′),"_xint")), libbid), $Ti′, ($BID,), x), InexactError, INVALID | OVERFLOW)
-        Base.floor(::Type{Integer}, x::$BID) = xchk(ccall(($(bidsym(w,"to_",lowercase(i′),"_xfloor")), libbid), $Ti′, ($BID,), x), InexactError, INVALID | OVERFLOW)
-        Base.ceil(::Type{Integer}, x::$BID) = xchk(ccall(($(bidsym(w,"to_",lowercase(i′),"_xceil")), libbid), $Ti′, ($BID,), x), InexactError, INVALID | OVERFLOW)
-        Base.convert(::Type{Integer}, x::$BID) = xchk(ccall(($(bidsym(w,"to_",lowercase(i′),"_xfloor")), libbid), $Ti′, ($BID,), x), InexactError)
-    end
     for w′ in (8,16,32,64)
         for i′ in ("Int$w′", "UInt$w′")
             Ti′ = eval(Symbol(i′))
@@ -201,6 +193,11 @@ for w in (32,64,128)
     @eval Base.convert(::Type{Float16}, x::$BID) = convert(Float16, convert(Float32, x))
     @eval Base.reinterpret(::Type{$Ti}, x::$BID) = x.x
 end # widths w
+
+Base.trunc(::Type{Integer}, x::DecimalFloatingPoint) = trunc(Int, x)
+Base.floor(::Type{Integer}, x::DecimalFloatingPoint) = floor(Int, x)
+Base.ceil(::Type{Integer}, x::DecimalFloatingPoint) = ceil(Int, x)
+Base.convert(::Type{Integer}, x::DecimalFloatingPoint) = convert(Int, x)
 
 # the complex-sqrt function in base doesn't work for use, because it requires base-2 ldexp
 function Base.sqrt{T<:DecimalFloatingPoint}(z::Complex{T})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -81,15 +81,20 @@ for T in (Dec32, Dec64, Dec128)
     for Tf in (Float64, Float32, Float16)
         @test xd == Tf(x) == T(Tf(x)) == Tf(xd)
     end
-    for Ti in (Int8,UInt8,Int16,UInt16,Int32,UInt32,Int64,UInt64)
-        @test parse(T, "17") == T(Ti(17)) == Ti(17) == Ti(T(17))
-        @test floor(Ti, T(4.5)) == 4 == ceil(Ti, T(4.5)) - 1
+    for Ti in (Integer,Int8,UInt8,Int16,UInt16,Int32,UInt32,Int64,UInt64)
+        if Ti != Integer
+            @test parse(T, "17") == T(Ti(17)) == Ti(17) == Ti(T(17))
+        end
+        @test trunc(Ti, T(4.5)) == floor(Ti, T(4.5)) == 4 == ceil(Ti, T(4.5)) - 1
         @test_throws InexactError convert(Ti, xd)
+        @test_throws InexactError trunc(Ti, realmax(T))
         @test_throws InexactError floor(Ti, realmax(T))
         @test_throws InexactError ceil(Ti, realmax(T))
         if Ti <: Signed
             @test parse(T, "-17") == T(Ti(-17)) == Ti(-17) == Ti(T(-17))
-            @test floor(Ti, T(-4.5)) == -5 == ceil(Ti, T(-4.5)) - 1
+        end
+        if Ti <: Signed || Ti === Integer
+            @test floor(Ti, T(-4.5)) == -5 == trunc(Ti, T(-4.5)) - 1 == ceil(Ti, T(-4.5)) - 1
             @test_throws InexactError convert(Ti, yd)
         end
     end


### PR DESCRIPTION
The addition of `trunc` will help with the formatted printing issue #26.