### PR TITLE
Fix printf formatting

### DIFF
--- a/src/DecFP.jl
+++ b/src/DecFP.jl
@@ -79,6 +79,14 @@ function isnanstr(s::AbstractString)
     return true
 end
 
+function Base.show(io::IO, x::DecimalFloatingPoint)
+    s = @sprintf("%g", x)
+    if ismatch(r"^-?\d+$", s)
+        s *= ".0"
+    end
+    print(io, s)
+end
+
 for w in (32,64,128)
     BID = Symbol(string("Dec",w))
     Ti = eval(Symbol(string("UInt",w)))
@@ -104,11 +112,6 @@ for w in (32,64,128)
         end
 
         $BID(x::AbstractString) = parse($BID, x)
-
-        function Base.show(io::IO, x::$BID)
-            ccall(($(bidsym(w,"to_string")), libbid), Void, (Ptr{UInt8}, $BID), _buffer, x)
-            unsafe_write(io, pointer(_buffer), ccall(:strlen, Csize_t, (Ptr{UInt8},), _buffer))
-        end
 
         function Base.Printf.fix_dec(x::$BID, n::Int)
             if n > length(DIGITS) - 1

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,6 +37,52 @@ for T in (Dec32, Dec64, Dec128)
     @test parse(T,"-inf")::T == typemin(T)::T
 
     @test parse(T, "0.1")::T == T(1//10)
+    @test T("0.1")::T == T(1//10)
+
+    # some Dec128 tests fail due to Issue #47
+    if T != Dec128
+        @test @sprintf("%7.2f", T("1.2345")) == "   1.23"
+        @test @sprintf("%-7.2f", T("1.2345")) == "1.23   "
+        @test @sprintf("%07.2f", T("1.2345")) == "0001.23"
+        @test @sprintf("%.0f", T("1.2345")) == "1"
+        @test @sprintf("%#.0f", T("1.2345")) == "1."
+        @test @sprintf("%.4e", T("1.2345")) == "1.2345e+00"
+        @test @sprintf("%.4E", T("1.2345")) == "1.2345E+00"
+
+        @test @sprintf("%6.2f", T("9.999")) == " 10.00"
+        @test @sprintf("%9.2e", T("9.999e5")) == " 1.00e+06"
+
+        @test @sprintf("%f", T("Inf")) == "Inf"
+        @test @sprintf("%f", T("NaN")) == "NaN"
+
+        @test @sprintf("%.0e", T("3e42")) == "3e+42"
+        @test @sprintf("%#.0e", T("3e42")) == "3.e+42"
+
+        @test @sprintf("%e", T("3e42")) == "3.000000e+42"
+        @test @sprintf("%E", T("3e42")) == "3.000000E+42"
+        @test @sprintf("%e", T("3e-42")) == "3.000000e-42"
+        @test @sprintf("%E", T("3e-42")) == "3.000000E-42"
+
+        @sprintf("%.6g", T("12345670.")) == "1.23457e+07"
+        @sprintf("%.6g", T("1234567.")) == "1.23457e+06"
+        @sprintf("%.6g", T("123456.7")) == "123457"
+        @sprintf("%.6g", T("12345.67")) == "12345.7"
+        @sprintf("%.6g", T("12340000.0")) == "1.234e+07"
+
+        @test @sprintf("%10.5g", T("123.4")) == "     123.4"
+        @test @sprintf("%+10.5g", T("123.4")) == "    +123.4"
+        @test @sprintf("% 10.5g", T("123.4")) == "     123.4"
+        @test @sprintf("%#10.5g", T("123.4")) == "    123.40"
+        @test @sprintf("%-10.5g", T("123.4")) == "123.4     "
+        @test @sprintf("%-+10.5g", T("123.4")) == "+123.4    "
+        @test @sprintf("%010.5g", T("123.4")) == "00000123.4"
+        @test @sprintf("%10.5g", T("-123.4")) == "    -123.4"
+        @test @sprintf("%010.5g", T("-123.4")) == "-0000123.4"
+        @test @sprintf("%.6g", T("12340000.0")) == "1.234e+07"
+        @test @sprintf("%#.6g", T("12340000.0")) == "1.23400e+07"
+
+        @test @sprintf("%.2f %.4f", T("12.34567"), 9.87) == "12.35 9.8700"
+    end
 
     x,y,z = 1.5, -3.25, 0.0625 # exactly represented in binary
     xd = T(x); yd = T(y); zd = T(z)


### PR DESCRIPTION
Fixes Issue #26.  Implements %f %F %e %E %g %G.  Doesn't implement %a/%A.

I also added the Dec*(x::AbstractString) constructor to simplify writing the tests.