### PR TITLE
fix deprecation of Compat.KERNEL

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,5 +1,4 @@
 using BinDeps
-using Compat
 
 vers = "20U1"
 
@@ -7,7 +6,7 @@ url="https://bintray.com/artifact/download/julialang/generic/"
 tagfile = "installed_vers"
 target = "libbid$(Sys.WORD_SIZE).$(Libdl.dlext)"
 if !isfile(tagfile) || !isfile(target) || readchomp(tagfile) != "$vers:$(Sys.WORD_SIZE)"
-    if Compat.KERNEL == :NT
+    if Sys.KERNEL == :NT
         # binary for Windows was cross-compiled with mingw using:
         # 32-bit: CC_NAME_INDEX=3 CC_INDEX=3 _HOST_OS=Windows_NT _HOST_ARCH=x86 _NUM_CPUS=1 CC=i686-w64-mingw32-gcc CFLAGS_OPT="-O2 -DBID_THREAD= -DBID_MS_FLAGS" CALL_BY_REF=0 GLOBAL_RND=1 GLOBAL_FLAGS=1 UNCHANGED_BINARY_FLAGS=1
         # 64-bit: CC_NAME_INDEX=3 CC_INDEX=3 _HOST_OS=Windows_NT _HOST_ARCH=x86_64 _NUM_CPUS=1 CC=x86_64-w64-mingw32-gcc CFLAGS_OPT="-O2 -DBID_THREAD= -DBID_MS_FLAGS" CALL_BY_REF=0 GLOBAL_RND=1 GLOBAL_FLAGS=1 UNCHANGED_BINARY_FLAGS=1
@@ -16,7 +15,7 @@ if !isfile(tagfile) || !isfile(target) || readchomp(tagfile) != "$vers:$(Sys.WOR
         #   libbid.dll: $(ALL_BID_OBJS)
         #           $(CC) -shared -o $@ $(ALL_BID_OBJS)
         run(download_cmd(url*"libbid$(Sys.WORD_SIZE)-$vers.dll", target))
-    elseif Compat.KERNEL == :Darwin
+    elseif Sys.KERNEL == :Darwin
         run(download_cmd(url*"libbid$(Sys.WORD_SIZE)-$vers.dylib", target))
     else
         tarball = "IntelRDFPMathLib$vers.tar.gz"


### PR DESCRIPTION
Also, I don't think Compat is needed in the build file anymore.