### PR TITLE
ismatch deprecation

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.6
-Compat 0.40.0
+Compat 0.46.0
 BinDeps

--- a/src/DecFP.jl
+++ b/src/DecFP.jl
@@ -73,7 +73,7 @@ end
 
 function Base.show(io::IO, x::DecimalFloatingPoint)
     s = @sprintf("%g", x)
-    if ismatch(r"^-?\d+$", s)
+    if contains(s, r"^-?\d+$")
         s *= ".0"
     end
     print(io, s)


### PR DESCRIPTION
I will work on a better `show`, but for now eliminate the `ismatch` deprecation warning.