### PR TITLE
Round without overflow (Fix #59)

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -195,8 +195,8 @@ for T in (Dec32, Dec64, Dec128)
     @test_throws DomainError sqrt(yd)
     @test_throws DomainError acosh(zd)
 
-    # @test ldexp(parse(T, "1"), 3) == 1000
-    # @test exponent(parse(T, "1000")) == 3
+    @test DecFP.ldexp10(parse(T, "1"), 3) == 1000
+    @test DecFP.exponent10(parse(T, "1000")) == 3
     @test sqrt(complex(yd)) ≈ sqrt(complex(y))
 
     @test typeof(xd * pi) == T


### PR DESCRIPTION
Fixes #59 
```
julia> @sprintf("%e", realmin(Dec64))
"1.000000e-398"

julia> realmax(Dec64)
9.999999999999999e384

julia> @sprintf("%e", realmax(Dec64))
"1.000000e+385"
```
I uncommented the definitions for `exponent` and `ldexp` and renamed to `exponent10` and `ldexp10` to avoid confusion with Base `exponent` and `ldexp`.  I like the name `scale10` better than `ldexp10`.  Do you have a preference on this?  I am currently using these within `DecFP.jl` but not exporting them.  I also defined `tostring` to wrap the library's `to_string`.  I welcome a better name for this.